### PR TITLE
Add presetter as a build tool for building a typescript project

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,10 @@ The resources of this article are mainly from the following websites：
 
 - [palantir - tslint](https://github.com/palantir/tslint)
 
+#### config management
+
+- [presetter](https://github.com/alvis/presetter)
+
 ### Ioc
 
 * [Inversify - InversifyJS](https://github.com/inversify/InversifyJS)


### PR DESCRIPTION
Presetter is a build system management tool that allows developers to reuse and manage build scripts, devDependencies and config files from presets for a typescript project. Example presets include build configs for setting up a react component library with tsx support, and a modern library written in typescript with dual ESM/CJS export.