### PR TITLE
Add `diod` (IoC library)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -377,6 +377,7 @@
 
 * [Inversify - InversifyJS](https://github.com/inversify/InversifyJS)
 * [Inversify - inversify-express-example](https://github.com/inversify/inversify-express-example)
+* [DIOD - diod](https://github.com/artberri/diod)
 
 ### 文档生成
 

--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ The resources of this article are mainly from the following websites：
 * [Inversify - inversify-express-example](https://github.com/inversify/inversify-express-example)
 * [Injex Framework](https://www.injex.dev)
 * [Injex Express Plugin](https://www.injex.dev/docs/plugins/express)
+* [DIOD - diod](https://github.com/artberri/diod)
 
 ### Doc
 


### PR DESCRIPTION
Add `diod` (IoC library).

A very opinionated and lightweight (under 2kB minified and gzipped) inversion of control container and dependency injector for Node.js or browser apps. It is available for vanilla Javascript usage but its true power will be shown by building Typescript apps.

Disclaimer: I am the author.