### PR TITLE
Add React Starter Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@
 
 ## TypeScript Starters/Boilerplates
 
+- [Kriasoft - React Starter Kit](https://github.com/kriasoft/react-starter-kit)
 - [Microsoft - TypeScript-React-Starter](https://github.com/Microsoft/TypeScript-React-Starter)
 - [Microsoft - TypeScript-Vue-Starter](https://github.com/Microsoft/TypeScript-Vue-Starter)
 - [Microsoft - TypeScript-Knockout-Starter](https://github.com/Microsoft/TypeScript-Knockout-Starter)


### PR DESCRIPTION
React Starter Kit is a boilerplate for building modern full-stack web applications with Bun, TypeScript, React, tRPC, and Drizzle ORM. It is designed to be a starting point for developers who want to create modern web applications with a focus on performance, simplicity, and best practices, with out-of-the-box support for edge-native deployment on Cloudflare Workers.

Repository: https://github.com/kriasoft/react-starter-kit
License: MIT