### PR TITLE
Add nestjs-doctor to linter section

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@
 - [palantir - tslint](https://github.com/palantir/tslint)
 - [ESLint](https://eslint.org/)
 - [Open Code Review](https://github.com/raye-deng/open-code-review) - AI code quality gate detecting hallucinated packages, phantom dependencies, stale APIs, and AI-specific code defects. MCP Server + CLI + CI/CD.
+- [nestjs-doctor](https://github.com/RoloBits/nestjs-doctor) - Static analysis and diagnostics for NestJS projects with 30+ lint rules, health scores, module graph visualization, and endpoint dependency graphs. CLI + VS Code extension.
 
 ### Ioc
 


### PR DESCRIPTION
Adds nestjs-doctor to the linter section.

- Open source (MIT), 90+ GitHub stars
- Static analysis and diagnostics tool purpose-built for NestJS (TypeScript)
- 50+ lint rules covering correctness, security, architecture, and performance
- 0-100 health score with actionable diagnostics
- Module graph visualization and endpoint dependency graphs
- Database schema analysis (Prisma, TypeORM, Drizzle)
- Zero config, monorepo support
- CLI and VS Code extension
- https://github.com/RoloBits/nestjs-doctor