### PR TITLE
Add cuechain to TypeScript Tools/Libraries > Utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@
 ### Utility
 
 - [PigmentTS](https://github.com/Jay-Karia/pigment-ts)
+- [CueAPI - cuechain](https://github.com/cueapi/cuechain) - TypeScript primitive for verifying contracts between LLM pipeline steps. Typed inputs/outputs via Zod, quality gates with retry and failure context. MIT.
 
 ## TypeScript IDE
 


### PR DESCRIPTION
Adds cuechain to `TypeScript Tools/Libraries` → `Utility`.

cuechain is a TypeScript primitive for verifying contracts between LLM pipeline steps — typed inputs/outputs via Zod, with quality gates that retry with failure context. MIT.

Repo: https://github.com/cueapi/cuechain

Followed the contribution guide: added at end of the section, format consistent with surrounding entries. If Utility is the wrong home, happy to move it wherever you prefer.