### PR TITLE
Add SolvoHQ - json-to-ts to Tools/Libraries → compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@
 - [AssemblyScript - assemblyscript](https://github.com/AssemblyScript/assemblyscript)
 - [bcherny - json-schema-to-typescript](https://github.com/bcherny/json-schema-to-typescript)
 - [YousefED - typescript-json-schema](https://github.com/YousefED/typescript-json-schema)
+- [SolvoHQ - json-to-ts](https://github.com/SolvoHQ/json-to-ts) - Browser-based JSON-sample to TypeScript interface/type converter. Live demo: https://json-to-ts-app.netlify.app
 
 #### linter
 


### PR DESCRIPTION
Adds [SolvoHQ - json-to-ts](https://github.com/SolvoHQ/json-to-ts) under **TypeScript Tools/Libraries → Build → compiler**, alongside `bcherny - json-schema-to-typescript` and `YousefED - typescript-json-schema`.

It is a focused JSON-sample → TypeScript interface/type converter that runs entirely in the browser (live demo: https://json-to-ts-app.netlify.app). Source is MIT-licensed at https://github.com/SolvoHQ/json-to-ts.

Fits the existing list because it solves the same code-generation problem as the two neighbours, with a JSON-sample input shape rather than a JSON-schema input shape.