### PR TITLE
Add jsontosdk to compiler section

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@
 - [AssemblyScript - assemblyscript](https://github.com/AssemblyScript/assemblyscript)
 - [bcherny - json-schema-to-typescript](https://github.com/bcherny/json-schema-to-typescript)
 - [YousefED - typescript-json-schema](https://github.com/YousefED/typescript-json-schema)
+- [SolvoHQ - jsontosdk](https://github.com/SolvoHQ/jsontosdk) - Paste a JSON sample, get a typed TypeScript interface + Zod schema with LLM-named types. No signup. Live demo at [jsontosdk.vercel.app](https://jsontosdk.vercel.app).
 
 #### linter
 


### PR DESCRIPTION
Adds **jsontosdk** under `TypeScript Tools/Libraries → Build → compiler`,
alongside `json-schema-to-typescript` / `typescript-json-schema`.

- Live tool: https://jsontosdk.vercel.app
- Repo: https://github.com/SolvoHQ/jsontosdk
- What it does: paste a JSON sample → typed TS interfaces + Zod schema in
  ~5s. Types are LLM-named (so nested objects get sensible names like
  `User` / `Post`, not `_C` / `_C1`) and the Zod schema uses the same
  identifiers as the interfaces.
- Fills the gap between [quicktype](https://quicktype.io) (great UX,
  generic names) and ChatGPT (good naming, no persistent URL, no Zod).
- No signup, free for payloads ≤100 KB, 20 generations/hr/IP.

Entry added at the end of the `compiler` subsection per the contributing
guidelines (append, keep format consistent).