### PR TITLE
Add TutorialSearch to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@
 
 - [Microsoft - TypeScript-Handbook](https://github.com/Microsoft/TypeScript-Handbook)
 - [Microsoft - TypeScript Team Blog](http://blogs.msdn.com/b/typescript/)
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 - [TypeStrong - Learn TypeScript](https://github.com/TypeStrong/learn-typescript)
 - [Indrek Lasn - TypeScript — JavaScript with superpowers](https://medium.freecodecamp.org/typescript-javascript-with-super-powers-a333b0fcabc9)
 - [Indrek Lasn - TypeScript — JavaScript with superpowers II](https://hackernoon.com/typescript-javascript-with-superpowers-part-ii-69a6bd2c6842)


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Tutorials* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/programming-languages/node-typescript) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/programming-languages/node-typescript) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.