### PR TITLE
Add Voight to Utility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@
 ### Utility
 
 - [PigmentTS](https://github.com/Jay-Karia/pigment-ts)
+- [Voightxyz - voight-sdk](https://github.com/Voightxyz/voight-sdk) - Real-time LLM observability. Drop-in wrappers for OpenAI, Anthropic, Vercel AI SDK + hooks for Claude Code and Cursor capture prompts, tokens, tool calls, cost, latency, and errors.
 
 ## TypeScript IDE
 


### PR DESCRIPTION
Adds Voight to the Tools/Libraries → Utility section.

TypeScript SDK for real-time LLM observability. Drop-in wrappers around the official OpenAI / Anthropic Node SDKs + the Vercel AI SDK capture every model call. Also provides hooks for Claude Code and Cursor.

- Repo: https://github.com/Voightxyz/voight-sdk
- npm: @voightxyz/sdk, @voightxyz/openai, @voightxyz/anthropic, @voightxyz/vercel-ai
- License: Apache 2.0