### PR TITLE
Add capcut-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@
 ### Utility
 
 - [PigmentTS](https://github.com/Jay-Karia/pigment-ts)
+- [capcut-cli](https://github.com/renezander030/capcut-cli)
 
 ## TypeScript IDE
 


### PR DESCRIPTION
Adds [capcut-cli](https://github.com/renezander030/capcut-cli) under **TypeScript Tools/Libraries > Utility**.

A zero-dependency TypeScript CLI and typed library for reading and writing CapCut / JianYing (剪映) draft files. MIT, on npm, actively maintained.