### PR TITLE
Add ts-mixin-class to compiler section

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@
 - [AssemblyScript - assemblyscript](https://github.com/AssemblyScript/assemblyscript)
 - [bcherny - json-schema-to-typescript](https://github.com/bcherny/json-schema-to-typescript)
 - [YousefED - typescript-json-schema](https://github.com/YousefED/typescript-json-schema)
-- [tonyboho - ts-mixin-class](https://github.com/tonyboho/ts-mixin-class) - Multiple inheritance for TypeScript with native syntax, full generics support and zero runtime overhead
+- [tonyboho - ts-mixin-class](https://github.com/tonyboho/ts-mixin-class)
 
 #### linter
 

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@
 - [AssemblyScript - assemblyscript](https://github.com/AssemblyScript/assemblyscript)
 - [bcherny - json-schema-to-typescript](https://github.com/bcherny/json-schema-to-typescript)
 - [YousefED - typescript-json-schema](https://github.com/YousefED/typescript-json-schema)
+- [tonyboho - ts-mixin-class](https://github.com/tonyboho/ts-mixin-class) - Multiple inheritance for TypeScript with native syntax, full generics support and zero runtime overhead
 
 #### linter
 


### PR DESCRIPTION
Adds [ts-mixin-class](https://github.com/tonyboho/ts-mixin-class) to **Tools/Libraries → Build → compiler**.

It's a `ts-patch` compiler transformer that adds multiple inheritance to TypeScript through the native `implements` keyword — full generics, C3 linearization, and zero runtime overhead. Entry follows the section's `- [author - name](url) - description` format.