### PR TITLE
Add ts6to7 to CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@
 
 ### CLI
 - [capcut-cli](https://github.com/renezander030/capcut-cli)
+- [ts6to7](https://github.com/zi-gae/ts6to7) - Codemod that migrates a TypeScript 5/6 project to TypeScript 7 (tsgo): rewrites tsconfig options removed in TS7 and flags changes that need manual review.
 
 ## TypeScript IDE
 


### PR DESCRIPTION
Adds [ts6to7](https://github.com/zi-gae/ts6to7) to the **Tools/Libraries → CLI** section.

ts6to7 is a codemod that migrates a TypeScript 5 or 6 project to TypeScript 7 (tsgo), which went GA this week. It rewrites the tsconfig options TS7 removed (`target: es5`, `module: umd`, `baseUrl`, `importsNotUsedAsValues`, ...) in place — preserving comments and formatting — bumps the `typescript` dependency, and prints a checklist of everything it can't safely change. Try it with `npx ts6to7 --dry`.

Followed the guide: added at the end of the section, format consistent with existing items.

(Disclosure: I'm the author.)