### PR TITLE
Add Kostra to TypeScript Starters/Boilerplates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@
 - [w3tecch - express-typescript-boilerplate](https://github.com/w3tecch/express-typescript-boilerplate)
 - [kamahl19 - react-starter](https://github.com/Kamahl19/react-starter)
 - [jsynowiec - node-typescript-boilerplate](https://github.com/jsynowiec/node-typescript-boilerplate)
+- [Kostra](https://kostra.io) - Next.js SaaS boilerplate with strict TypeScript, Prisma, Stripe billing, and credit-based usage billing.
 
 ## TypeScript Design patterns
 


### PR DESCRIPTION
Adds Kostra, a Next.js SaaS boilerplate with strict TypeScript (no `any`, fully typed from Prisma to UI), Stripe billing, and credit-based usage billing, to the TypeScript Starters/Boilerplates section. Entry is appended at the end of the list per the existing format.