### PR TITLE
Add Tura to TypeScript CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@
 - [capcut-cli](https://github.com/renezander030/capcut-cli)
 
 * [reflow](https://github.com/valtors/reflow) - SSR-safe responsive toolkit for TypeScript. Breakpoints, container queries, fluid typography, and user preference hooks. Works across React, Vue, Svelte, Solid, Qwik, Preact, Angular, and Lit.
+- [Tura](https://github.com/Tura-AI/tura) - Local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it.
 
 ## TypeScript IDE
 


### PR DESCRIPTION
## Why include Tura

- [Tura](https://github.com/Tura-AI/tura) is distributed as the `tura-ai` npm CLI and includes TypeScript TUI and GUI workspaces; GitHub currently reports TypeScript as 19.6% of the repository.
- It is a direct fit for the existing **TypeScript Tools/Libraries → CLI** section and has been added at the bottom as requested.
- **16.7% better performance, 77.5% fewer rounds.**

Tura is a local, open-source coding agent for developers who are tired of vague skill claims, token-saving extensions with no evidence, and agents that change a repository before understanding it. The benchmark methodology and evidence are published at https://turaai.net/benchmark.

I am affiliated with the Tura project. AI assistance was used to audit the contribution rules, prepare the one-entry README change, and draft this pull request; I reviewed the final diff and description.