### PR TITLE
Add Markstream to TypeScript utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@
 
 - [PigmentTS](https://github.com/Jay-Karia/pigment-ts)
 - [csv-pipe](https://github.com/martsinlabs/csv-pipe)
+- [Markstream](https://github.com/Simon-He95/markstream-vue) - Streaming Markdown renderer for AI chat interfaces, with Vue, React, Svelte, Angular, and Vue 2 packages plus Mermaid, KaTeX, syntax highlighting, safe HTML, and SSR support.
 
 ### CLI
 - [capcut-cli](https://github.com/renezander030/capcut-cli)


### PR DESCRIPTION
Hi, thanks for maintaining this list.

This adds [Markstream](https://github.com/Simon-He95/markstream-vue) to the Utility section. Markstream is an MIT-licensed TypeScript renderer for streaming Markdown in AI chat interfaces, with packages for Vue, React, Svelte, Angular, and Vue 2. It supports incomplete Markdown tokens, Mermaid, KaTeX, syntax highlighting, safe HTML, and SSR.

I added it at the end of the existing list, following the contribution guide. Thanks for considering it.