### PR TITLE
Add rrweb

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@
 - [PigmentTS](https://github.com/Jay-Karia/pigment-ts)
 - [csv-pipe](https://github.com/martsinlabs/csv-pipe)
 - [Markstream](https://github.com/Simon-He95/markstream-vue) - Streaming Markdown renderer for AI chat interfaces, with Vue, React, Svelte, Angular, and Vue 2 packages plus Mermaid, KaTeX, syntax highlighting, safe HTML, and SSR support.
+- [rrweb](https://github.com/rrweb-io/rrweb) - Records the DOM and user interactions as a typed JSON event stream and replays them pixel-perfect.
 
 ### CLI
 - [capcut-cli](https://github.com/renezander030/capcut-cli)


### PR DESCRIPTION
Adds rrweb under TypeScript Tools/Libraries → Utility.

rrweb is a TypeScript library that records the DOM and user interactions as a typed JSON event stream and replays them. Added at the end of the section matching the current items' format, per the contributing guide.

- Repo: https://github.com/rrweb-io/rrweb (19,899 stars, MIT)
- Docs: https://rrweb.com/docs/

Disclosure: I work on rrweb.
