### PR TITLE
Add JSON to TypeScript to Utility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@
 - [PigmentTS](https://github.com/Jay-Karia/pigment-ts)
 - [csv-pipe](https://github.com/martsinlabs/csv-pipe)
 - [Markstream](https://github.com/Simon-He95/markstream-vue) - Streaming Markdown renderer for AI chat interfaces, with Vue, React, Svelte, Angular, and Vue 2 packages plus Mermaid, KaTeX, syntax highlighting, safe HTML, and SSR support.
+- [JSON to TypeScript](https://nutilz.com/json-to-typescript) - Free online tool that converts JSON objects into TypeScript interfaces and types, no signup required.
 
 ### CLI
 - [capcut-cli](https://github.com/renezander030/capcut-cli)


### PR DESCRIPTION
Adds [JSON to TypeScript](https://nutilz.com/json-to-typescript), a free online tool that converts JSON objects into TypeScript interfaces/types with no signup required. Added as a single line at the end of the Utility section under TypeScript Tools/Libraries, matching the existing format.