### PR TITLE
Add mdgate/converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
       - [linter](#linter)
     - [Ioc](#ioc)
     - [Doc](#doc)
+    - [Converter](#converter)
     - [Data Structure](#data-structure)
     - [Database](#database)
     - [Server](#server)
@@ -378,6 +379,10 @@
 ### Doc
 
 - [TypeStrong - typedoc](https://github.com/TypeStrong/typedoc)
+
+### Converter
+
+- [mdgate - converters](https://github.com/mdgate/converters) - Pure TypeScript converters for 150+ file types (DOCX, PDF, PPTX, XLSX, iWork, HWP, email) to GitHub-Flavored Markdown. Runs in Node, Edge, and browsers.
 
 ### Data Structure
 


### PR DESCRIPTION
## Summary

- Add [mdgate/converters](https://github.com/mdgate/converters), a MIT-licensed TypeScript library that converts DOCX, PDF, PPTX, XLSX, iWork, HWP, email, and 150+ other file types to GitHub-Flavored Markdown.
- It runs in Node, Cloudflare Workers / Edge, and browsers, with no Python, WASM, or native addons.
- Demo: https://convert.mdgate.dev

## Why include it

Most document-to-Markdown tools are Python services or native binaries. This one is a portable TypeScript package, which is useful for JS/TS apps, RAG ingestion, and Cloudflare Workers.
